### PR TITLE
Fixed ObjectType to be assignable from the PHP "object" type

### DIFF
--- a/src/ObjectType.php
+++ b/src/ObjectType.php
@@ -41,6 +41,10 @@ final class ObjectType extends Type
             if (\is_subclass_of($other->className->getQualifiedName(), $this->className->getQualifiedName(), true)) {
                 return true;
             }
+
+            if ($other->className->getQualifiedName() === 'object') {
+                return true;
+            }
         }
 
         return false;

--- a/tests/unit/ObjectTypeTest.php
+++ b/tests/unit/ObjectTypeTest.php
@@ -119,4 +119,26 @@ final class ObjectTypeTest extends TestCase
 
         $this->assertTrue($someClass->allowsNull());
     }
+
+    public function testObjectTypeIsAssignableToObjects(): void
+    {
+        $objectType = new ObjectType(
+            TypeName::fromQualifiedName('object'),
+            true
+        );
+        $someObject = new class() {
+            // Empty
+        };
+        $this->assertTrue(Type::fromValue($someObject, false)->isAssignable($objectType));
+    }
+
+    public function testObjectTypeIsNotAssignableToNonObjects(): void
+    {
+        $objectType = new ObjectType(
+            TypeName::fromQualifiedName('object'),
+            true
+        );
+        $someNonObject = 123;
+        $this->assertFalse(Type::fromValue($someNonObject, false)->isAssignable($objectType));
+    }
 }


### PR DESCRIPTION
This should fix the [issue raised here](https://github.com/sebastianbergmann/phpunit/issues/3706).  Basically, this allows object types to be assignable from `object`.  Before, we were only checking if the object was the same class or a subclass of the type you're trying to assign to.