### PR TITLE
Restore skipped tests after merge in php-src

### DIFF
--- a/tests/unit/ReflectionMapperTest.php
+++ b/tests/unit/ReflectionMapperTest.php
@@ -148,8 +148,6 @@ final class ReflectionMapperTest extends TestCase
      */
     public function testMapsFromFalseReturnType(): void
     {
-        $this->markTestSkipped('https://github.com/php/php-src/pull/7546 has not been merged yet');
-
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresFalseReturnType::class, 'falseReturnType'));
 
         $this->assertInstanceOf(FalseType::class, $type);
@@ -161,8 +159,6 @@ final class ReflectionMapperTest extends TestCase
      */
     public function testMapsFromNullReturnType(): void
     {
-        $this->markTestSkipped('https://github.com/php/php-src/pull/7546 has not been merged yet');
-
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresNullReturnType::class, 'nullReturnType'));
 
         $this->assertInstanceOf(NullType::class, $type);


### PR DESCRIPTION
Reverts 6a84c28d0af3f09ffd407b0391796a87d2c07b07

https://github.com/php/php-src/pull/7546 has been merged so these tests can be "unskipped".