### PR TITLE
Backport 8.0 and 8.1 types into branch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 All notable changes are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [1.2.0] - 2022-MM-DD
+* Backported support for union and intersection types
+* Backported name method
+
 ## [1.1.4] - 2020-11-30
 
 ### Changed

--- a/src/CallableType.php
+++ b/src/CallableType.php
@@ -61,9 +61,9 @@ final class CallableType extends Type
         return false;
     }
 
-    public function getReturnTypeDeclaration(): string
+    public function name(): string
     {
-        return ': ' . ($this->allowsNull ? '?' : '') . 'callable';
+        return 'callable';
     }
 
     public function allowsNull(): bool

--- a/src/GenericObjectType.php
+++ b/src/GenericObjectType.php
@@ -34,9 +34,9 @@ final class GenericObjectType extends Type
         return true;
     }
 
-    public function getReturnTypeDeclaration(): string
+    public function name(): string
     {
-        return ': ' . ($this->allowsNull ? '?' : '') . 'object';
+        return 'object';
     }
 
     public function allowsNull(): bool

--- a/src/IntersectionType.php
+++ b/src/IntersectionType.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/type.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Type;
+
+final class IntersectionType extends Type
+{
+    /**
+     * @psalm-var list<Type>
+     */
+    private $types;
+
+    /**
+     * @throws RuntimeException
+     */
+    public function __construct(Type ...$types)
+    {
+        $this->ensureMinimumOfTwoTypes(...$types);
+        $this->ensureOnlyValidTypes(...$types);
+        $this->ensureNoDuplicateTypes(...$types);
+
+        $this->types = $types;
+    }
+
+    public function isAssignable(Type $other): bool
+    {
+        return $other instanceof ObjectType;
+    }
+
+    public function asString(): string
+    {
+        return $this->name();
+    }
+
+    public function getReturnTypeDeclaration(): string
+    {
+        return ': ' . $this->name();
+    }
+
+    public function name(): string
+    {
+        $types = [];
+
+        foreach ($this->types as $type) {
+            $types[] = $type->name();
+        }
+
+        \sort($types);
+
+        return \implode('&', $types);
+    }
+
+    public function allowsNull(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function ensureMinimumOfTwoTypes(Type ...$types): void
+    {
+        if (\count($types) < 2) {
+            throw new RuntimeException(
+                'An intersection type must be composed of at least two types'
+            );
+        }
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function ensureOnlyValidTypes(Type ...$types): void
+    {
+        foreach ($types as $type) {
+            if (!$type instanceof ObjectType) {
+                throw new RuntimeException(
+                    'An intersection type can only be composed of interfaces and classes'
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function ensureNoDuplicateTypes(Type ...$types): void
+    {
+        $names = [];
+
+        foreach ($types as $type) {
+            \assert($type instanceof ObjectType);
+
+            $names[] = $type->className()->getQualifiedName();
+        }
+
+        if (\count(\array_unique($names)) < \count($names)) {
+            throw new RuntimeException(
+                'An intersection type must not contain duplicate types'
+            );
+        }
+    }
+}

--- a/src/IterableType.php
+++ b/src/IterableType.php
@@ -55,9 +55,9 @@ final class IterableType extends Type
         return false;
     }
 
-    public function getReturnTypeDeclaration(): string
+    public function name(): string
     {
-        return ': ' . ($this->allowsNull ? '?' : '') . 'iterable';
+        return 'iterable';
     }
 
     public function allowsNull(): bool

--- a/src/NullType.php
+++ b/src/NullType.php
@@ -16,6 +16,16 @@ final class NullType extends Type
         return !($other instanceof VoidType);
     }
 
+    public function name(): string
+    {
+        return 'null';
+    }
+
+    public function asString(): string
+    {
+        return 'null';
+    }
+
     public function getReturnTypeDeclaration(): string
     {
         return '';

--- a/src/ObjectType.php
+++ b/src/ObjectType.php
@@ -46,9 +46,9 @@ final class ObjectType extends Type
         return false;
     }
 
-    public function getReturnTypeDeclaration(): string
+    public function name(): string
     {
-        return ': ' . ($this->allowsNull ? '?' : '') . $this->className->getQualifiedName();
+        return $this->className->getQualifiedName();
     }
 
     public function allowsNull(): bool

--- a/src/SimpleType.php
+++ b/src/SimpleType.php
@@ -46,6 +46,11 @@ final class SimpleType extends Type
         return false;
     }
 
+    public function name(): string
+    {
+        return $this->name;
+    }
+
     public function getReturnTypeDeclaration(): string
     {
         return ': ' . ($this->allowsNull ? '?' : '') . $this->name;

--- a/src/Type.php
+++ b/src/Type.php
@@ -67,9 +67,19 @@ abstract class Type
         }
     }
 
-    abstract public function isAssignable(Type $other): bool;
+    public function asString(): string
+    {
+        return ($this->allowsNull() ? '?' : '') . $this->name();
+    }
 
-    abstract public function getReturnTypeDeclaration(): string;
+    public function getReturnTypeDeclaration(): string
+    {
+        return ': ' . $this->asString();
+    }
+
+    abstract public function isAssignable(self $other): bool;
+
+    abstract public function name(): string;
 
     abstract public function allowsNull(): bool;
 }

--- a/src/UnionType.php
+++ b/src/UnionType.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/type.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Type;
+
+final class UnionType extends Type
+{
+    /**
+     * @psalm-var list<Type>
+     */
+    private $types;
+
+    /**
+     * @throws RuntimeException
+     */
+    public function __construct(Type ...$types)
+    {
+        $this->ensureMinimumOfTwoTypes(...$types);
+        $this->ensureOnlyValidTypes(...$types);
+
+        $this->types = $types;
+    }
+
+    public function isAssignable(Type $other): bool
+    {
+        foreach ($this->types as $type) {
+            if ($type->isAssignable($other)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function asString(): string
+    {
+        return $this->name();
+    }
+
+    public function getReturnTypeDeclaration(): string
+    {
+        return ': ' . $this->name();
+    }
+
+    public function name(): string
+    {
+        $types = [];
+
+        foreach ($this->types as $type) {
+            $types[] = $type->name();
+        }
+
+        \sort($types);
+
+        return \implode('|', $types);
+    }
+
+    public function allowsNull(): bool
+    {
+        foreach ($this->types as $type) {
+            if ($type instanceof NullType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function ensureMinimumOfTwoTypes(Type ...$types): void
+    {
+        if (\count($types) < 2) {
+            throw new RuntimeException(
+                'A union type must be composed of at least two types'
+            );
+        }
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function ensureOnlyValidTypes(Type ...$types): void
+    {
+        foreach ($types as $type) {
+            if ($type instanceof UnknownType) {
+                throw new RuntimeException(
+                    'A union type must not be composed of an unknown type'
+                );
+            }
+
+            if ($type instanceof VoidType) {
+                throw new RuntimeException(
+                    'A union type must not be composed of a void type'
+                );
+            }
+        }
+    }
+}

--- a/src/UnknownType.php
+++ b/src/UnknownType.php
@@ -16,6 +16,16 @@ final class UnknownType extends Type
         return true;
     }
 
+    public function name(): string
+    {
+        return 'unknown type';
+    }
+
+    public function asString(): string
+    {
+        return '';
+    }
+
     public function getReturnTypeDeclaration(): string
     {
         return '';

--- a/src/VoidType.php
+++ b/src/VoidType.php
@@ -16,6 +16,11 @@ final class VoidType extends Type
         return $other instanceof self;
     }
 
+    public function name(): string
+    {
+        return 'void';
+    }
+
     public function getReturnTypeDeclaration(): string
     {
         return ': void';

--- a/tests/unit/CallableTypeTest.php
+++ b/tests/unit/CallableTypeTest.php
@@ -16,9 +16,9 @@ use SebastianBergmann\Type\TestFixture\ClassWithInvokeMethod;
 /**
  * @covers \SebastianBergmann\Type\CallableType
  *
- * @uses \SebastianBergmann\Type\Type
  * @uses \SebastianBergmann\Type\ObjectType
  * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\Type
  * @uses \SebastianBergmann\Type\TypeName
  */
 final class CallableTypeTest extends TestCase
@@ -142,7 +142,8 @@ final class CallableTypeTest extends TestCase
     {
         $this->assertFalse(
             $this->type->isAssignable(
-                Type::fromValue(new class {
+                Type::fromValue(new class
+                {
                 }, false)
             )
         );

--- a/tests/unit/GenericObjectTypeTest.php
+++ b/tests/unit/GenericObjectTypeTest.php
@@ -14,9 +14,9 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \SebastianBergmann\Type\GenericObjectType
  *
- * @uses \SebastianBergmann\Type\Type
  * @uses \SebastianBergmann\Type\ObjectType
  * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\Type
  * @uses \SebastianBergmann\Type\TypeName
  */
 final class GenericObjectTypeTest extends TestCase

--- a/tests/unit/IntersectionTypeTest.php
+++ b/tests/unit/IntersectionTypeTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/type.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Type;
+
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\Type\TestFixture\ChildClass;
+use SebastianBergmann\Type\TestFixture\ParentClass;
+
+/**
+ * @covers \SebastianBergmann\Type\IntersectionType
+ *
+ * @uses \SebastianBergmann\Type\NullType
+ * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\Type
+ */
+final class IntersectionTypeTest extends TestCase
+{
+    public function testCanBeRepresentedAsString(): void
+    {
+        $type = new IntersectionType(
+            Type::fromName(ParentClass::class, false),
+            Type::fromName(ChildClass::class, false)
+        );
+
+        $this->assertSame(ChildClass::class . '&' . ParentClass::class, $type->name());
+    }
+
+    public function testCanBeRepresentedAsStringForReturnTypeDeclaration(): void
+    {
+        $type = new IntersectionType(
+            Type::fromName(ParentClass::class, false),
+            Type::fromName(ChildClass::class, false)
+        );
+
+        $this->assertSame(': ' . ChildClass::class . '&' . ParentClass::class, $type->getReturnTypeDeclaration());
+    }
+
+    public function testDoesNotAllowNull(): void
+    {
+        $type = new IntersectionType(
+            Type::fromName(ParentClass::class, false),
+            Type::fromName(ChildClass::class, false)
+        );
+
+        $this->assertFalse($type->allowsNull());
+    }
+
+    public function testCannotBeCreatedFromLessThanTwoTypes(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new IntersectionType;
+    }
+
+    public function testEnsureNoDuplicateTypes(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new IntersectionType(
+            Type::fromName(ParentClass::class, false),
+            Type::fromName(ParentClass::class, false)
+        );
+    }
+
+    public function testCannotBeCreatedFromNonObjectType(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new IntersectionType(
+            Type::fromName('int', false),
+            Type::fromName('bool', false),
+        );
+    }
+}

--- a/tests/unit/IterableTypeTest.php
+++ b/tests/unit/IterableTypeTest.php
@@ -15,10 +15,10 @@ use SebastianBergmann\Type\TestFixture\Iterator;
 /**
  * @covers \SebastianBergmann\Type\IterableType
  *
- * @uses \SebastianBergmann\Type\Type
- * @uses \SebastianBergmann\Type\TypeName
  * @uses \SebastianBergmann\Type\ObjectType
  * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\Type
+ * @uses \SebastianBergmann\Type\TypeName
  */
 final class IterableTypeTest extends TestCase
 {

--- a/tests/unit/ObjectTypeTest.php
+++ b/tests/unit/ObjectTypeTest.php
@@ -16,9 +16,9 @@ use SebastianBergmann\Type\TestFixture\ParentClass;
 /**
  * @covers \SebastianBergmann\Type\ObjectType
  *
- * @uses \SebastianBergmann\Type\TypeName
- * @uses \SebastianBergmann\Type\Type
  * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\Type
+ * @uses \SebastianBergmann\Type\TypeName
  */
 final class ObjectTypeTest extends TestCase
 {

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -14,12 +14,12 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \SebastianBergmann\Type\Type
  *
- * @uses \SebastianBergmann\Type\SimpleType
- * @uses \SebastianBergmann\Type\GenericObjectType
- * @uses \SebastianBergmann\Type\ObjectType
- * @uses \SebastianBergmann\Type\TypeName
  * @uses \SebastianBergmann\Type\CallableType
+ * @uses \SebastianBergmann\Type\GenericObjectType
  * @uses \SebastianBergmann\Type\IterableType
+ * @uses \SebastianBergmann\Type\ObjectType
+ * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\TypeName
  */
 final class TypeTest extends TestCase
 {

--- a/tests/unit/UnionTypeTest.php
+++ b/tests/unit/UnionTypeTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/type.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Type;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \SebastianBergmann\Type\UnionType
+ *
+ * @uses \SebastianBergmann\Type\NullType
+ * @uses \SebastianBergmann\Type\SimpleType
+ * @uses \SebastianBergmann\Type\Type
+ */
+final class UnionTypeTest extends TestCase
+{
+    public function testCanBeRepresentedAsString(): void
+    {
+        $type = new UnionType(
+            Type::fromName('bool', false),
+            Type::fromName('int', false)
+        );
+
+        $this->assertSame('bool|int', $type->name());
+    }
+
+    public function testCanBeRepresentedAsStringForReturnTypeDeclaration(): void
+    {
+        $type = new UnionType(
+            Type::fromName('bool', false),
+            Type::fromName('int', false)
+        );
+
+        $this->assertSame(': bool|int', $type->getReturnTypeDeclaration());
+    }
+
+    public function testCanBeRepresentedAsStringForNullableReturnTypeDeclaration(): void
+    {
+        $type = new UnionType(
+            Type::fromName('bool', false),
+            Type::fromName('int', false),
+            Type::fromName('null', true)
+        );
+
+        $this->assertSame(': bool|int|null', $type->getReturnTypeDeclaration());
+    }
+
+    public function testMayAllowNull(): void
+    {
+        $type = new UnionType(
+            Type::fromName('bool', false),
+            Type::fromName('null', true)
+        );
+
+        $this->assertTrue($type->allowsNull());
+    }
+
+    public function testMayNotAllowNull(): void
+    {
+        $type = new UnionType(
+            Type::fromName('bool', false),
+            Type::fromName('int', false)
+        );
+
+        $this->assertFalse($type->allowsNull());
+    }
+
+    /**
+     * @dataProvider assignableProvider
+     */
+    public function testFoo(bool $expected, Type $type, UnionType $union): void
+    {
+        $this->assertSame($expected, $union->isAssignable($type));
+    }
+
+    public function assignableProvider(): array
+    {
+        return [
+            [
+                true,
+                Type::fromName('bool', false),
+                new UnionType(
+                    Type::fromName('bool', false),
+                    Type::fromName('int', false),
+                ),
+            ],
+            [
+                true,
+                Type::fromName('int', false),
+                new UnionType(
+                    Type::fromName('bool', false),
+                    Type::fromName('int', false),
+                ),
+            ],
+            [
+                false,
+                Type::fromName('string', false),
+                new UnionType(
+                    Type::fromName('bool', false),
+                    Type::fromName('int', false),
+                ),
+            ],
+        ];
+    }
+
+    public function testCannotBeCreatedFromLessThanTwoTypes(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new UnionType;
+    }
+
+    public function testCannotBeCreatedFromUnknownType(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new UnionType(
+            Type::fromName('int', false),
+            Type::fromName('unknown type', false)
+        );
+    }
+
+    public function testCannotBeCreatedFromVoidType(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        new UnionType(
+            Type::fromName('int', false),
+            Type::fromName('void', false)
+        );
+    }
+}


### PR DESCRIPTION
As part of https://github.com/sebastianbergmann/phpunit/issues/4879 you mentioned you were happy to accept pull requests for backporting union types into PHPUnit 8. As that ships with v1 of types this does a equivalent backport of both Union and Intersection types (as I was doing the union ones in the first place).