### PR TITLE
Upgrade/php 8.1 constructor properties

### DIFF
--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -12,27 +12,7 @@ namespace SebastianBergmann\Type;
 final class Parameter
 {
     /**
-     * @psalm-var non-empty-string
-     */
-    private string $name;
-    private Type $type;
-
-    /**
      * @psalm-param non-empty-string $name
      */
-    public function __construct(string $name, Type $type)
-    {
-        $this->name = $name;
-        $this->type = $type;
-    }
-
-    public function name(): string
-    {
-        return $this->name;
-    }
-
-    public function type(): Type
-    {
-        return $this->type;
-    }
+    public function __construct(public readonly string $name, public readonly Type $type) {}
 }

--- a/src/TypeName.php
+++ b/src/TypeName.php
@@ -17,8 +17,8 @@ use ReflectionClass;
 
 final class TypeName
 {
-    private ?string $namespaceName;
-    private string $simpleName;
+    public readonly ?string $namespaceName;
+    public readonly string $simpleName;
 
     public static function fromQualifiedName(string $fullClassName): self
     {
@@ -50,16 +50,6 @@ final class TypeName
 
         $this->namespaceName = $namespaceName;
         $this->simpleName    = $simpleName;
-    }
-
-    public function namespaceName(): ?string
-    {
-        return $this->namespaceName;
-    }
-
-    public function simpleName(): string
-    {
-        return $this->simpleName;
     }
 
     public function qualifiedName(): string

--- a/src/type/CallableType.php
+++ b/src/type/CallableType.php
@@ -76,12 +76,12 @@ final class CallableType extends Type
 
     private function isClosure(ObjectType $type): bool
     {
-        return $type->className()->qualifiedName() === Closure::class;
+        return $type->className->qualifiedName() === Closure::class;
     }
 
     private function hasInvokeMethod(ObjectType $type): bool
     {
-        $className = $type->className()->qualifiedName();
+        $className = $type->className->qualifiedName();
 
         assert(class_exists($className));
 

--- a/src/type/CallableType.php
+++ b/src/type/CallableType.php
@@ -90,64 +90,64 @@ final class CallableType extends Type
 
     private function isFunction(SimpleType $type): bool
     {
-        if (!is_string($type->value())) {
+        if (!is_string($type->value)) {
             return false;
         }
 
-        return function_exists($type->value());
+        return function_exists($type->value);
     }
 
     private function isObjectCallback(SimpleType $type): bool
     {
-        if (!is_array($type->value())) {
+        if (!is_array($type->value)) {
             return false;
         }
 
-        if (count($type->value()) !== 2) {
+        if (count($type->value) !== 2) {
             return false;
         }
 
-        if (!isset($type->value()[0], $type->value()[1])) {
+        if (!isset($type->value[0], $type->value[1])) {
             return false;
         }
 
-        if (!is_object($type->value()[0]) || !is_string($type->value()[1])) {
+        if (!is_object($type->value[0]) || !is_string($type->value[1])) {
             return false;
         }
 
-        [$object, $methodName] = $type->value();
+        [$object, $methodName] = $type->value;
 
         return (new ReflectionObject($object))->hasMethod($methodName);
     }
 
     private function isClassCallback(SimpleType $type): bool
     {
-        if (!is_string($type->value()) && !is_array($type->value())) {
+        if (!is_string($type->value) && !is_array($type->value)) {
             return false;
         }
 
-        if (is_string($type->value())) {
-            if (!str_contains($type->value(), '::')) {
+        if (is_string($type->value)) {
+            if (!str_contains($type->value, '::')) {
                 return false;
             }
 
-            [$className, $methodName] = explode('::', $type->value());
+            [$className, $methodName] = explode('::', $type->value);
         }
 
-        if (is_array($type->value())) {
-            if (count($type->value()) !== 2) {
+        if (is_array($type->value)) {
+            if (count($type->value) !== 2) {
                 return false;
             }
 
-            if (!isset($type->value()[0], $type->value()[1])) {
+            if (!isset($type->value[0], $type->value[1])) {
                 return false;
             }
 
-            if (!is_string($type->value()[0]) || !is_string($type->value()[1])) {
+            if (!is_string($type->value[0]) || !is_string($type->value[1])) {
                 return false;
             }
 
-            [$className, $methodName] = $type->value();
+            [$className, $methodName] = $type->value;
         }
 
         assert(isset($className) && is_string($className));

--- a/src/type/CallableType.php
+++ b/src/type/CallableType.php
@@ -24,6 +24,11 @@ use ReflectionObject;
 
 final class CallableType extends Type
 {
+    public function __construct(bool $allowsNull)
+    {
+        parent::__construct('callable', $allowsNull);
+    }
+
     public function isAssignable(Type $other): bool
     {
         if ($this->allowsNull && $other instanceof NullType) {
@@ -59,11 +64,6 @@ final class CallableType extends Type
         }
 
         return false;
-    }
-
-    public function name(): string
-    {
-        return 'callable';
     }
 
     /**

--- a/src/type/CallableType.php
+++ b/src/type/CallableType.php
@@ -24,13 +24,6 @@ use ReflectionObject;
 
 final class CallableType extends Type
 {
-    private bool $allowsNull;
-
-    public function __construct(bool $nullable)
-    {
-        $this->allowsNull = $nullable;
-    }
-
     public function isAssignable(Type $other): bool
     {
         if ($this->allowsNull && $other instanceof NullType) {
@@ -71,11 +64,6 @@ final class CallableType extends Type
     public function name(): string
     {
         return 'callable';
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     /**

--- a/src/type/FalseType.php
+++ b/src/type/FalseType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class FalseType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(false);
+    }
+
     public function isAssignable(Type $other): bool
     {
         if ($other instanceof self) {
@@ -25,11 +30,6 @@ final class FalseType extends Type
     public function name(): string
     {
         return 'false';
-    }
-
-    public function allowsNull(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/type/FalseType.php
+++ b/src/type/FalseType.php
@@ -24,7 +24,7 @@ final class FalseType extends Type
 
         return $other instanceof SimpleType &&
               $other->name === 'bool' &&
-              $other->value() === false;
+              $other->value === false;
     }
 
     /**

--- a/src/type/FalseType.php
+++ b/src/type/FalseType.php
@@ -13,7 +13,7 @@ final class FalseType extends Type
 {
     public function __construct()
     {
-        parent::__construct(false);
+        parent::__construct('false', false);
     }
 
     public function isAssignable(Type $other): bool
@@ -23,13 +23,8 @@ final class FalseType extends Type
         }
 
         return $other instanceof SimpleType &&
-              $other->name() === 'bool' &&
+              $other->name === 'bool' &&
               $other->value() === false;
-    }
-
-    public function name(): string
-    {
-        return 'false';
     }
 
     /**

--- a/src/type/GenericObjectType.php
+++ b/src/type/GenericObjectType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class GenericObjectType extends Type
 {
+    public function __construct(bool $allowsNull)
+    {
+        parent::__construct('object', $allowsNull);
+    }
+
     public function isAssignable(Type $other): bool
     {
         if ($this->allowsNull && $other instanceof NullType) {
@@ -22,11 +27,6 @@ final class GenericObjectType extends Type
         }
 
         return true;
-    }
-
-    public function name(): string
-    {
-        return 'object';
     }
 
     /**

--- a/src/type/GenericObjectType.php
+++ b/src/type/GenericObjectType.php
@@ -11,13 +11,6 @@ namespace SebastianBergmann\Type;
 
 final class GenericObjectType extends Type
 {
-    private bool $allowsNull;
-
-    public function __construct(bool $nullable)
-    {
-        $this->allowsNull = $nullable;
-    }
-
     public function isAssignable(Type $other): bool
     {
         if ($this->allowsNull && $other instanceof NullType) {
@@ -34,11 +27,6 @@ final class GenericObjectType extends Type
     public function name(): string
     {
         return 'object';
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     /**

--- a/src/type/IntersectionType.php
+++ b/src/type/IntersectionType.php
@@ -31,6 +31,8 @@ final class IntersectionType extends Type
         $this->ensureOnlyValidTypes(...$types);
         $this->ensureNoDuplicateTypes(...$types);
 
+        parent::__construct(false);
+
         $this->types = $types;
     }
 
@@ -55,11 +57,6 @@ final class IntersectionType extends Type
         sort($types);
 
         return implode('&', $types);
-    }
-
-    public function allowsNull(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/type/IntersectionType.php
+++ b/src/type/IntersectionType.php
@@ -23,6 +23,22 @@ final class IntersectionType extends Type
     private array $types;
 
     /**
+     * @psalm-param non-empty-list<ObjectType> $types
+     */
+    public static function getFullName(Type ...$types): string
+    {
+        $names = [];
+
+        foreach ($types as $type) {
+            $names[] = $type->name;
+        }
+
+        sort($names);
+
+        return implode('&', $names);
+    }
+
+    /**
      * @throws RuntimeException
      */
     public function __construct(Type ...$types)
@@ -31,7 +47,7 @@ final class IntersectionType extends Type
         $this->ensureOnlyValidTypes(...$types);
         $this->ensureNoDuplicateTypes(...$types);
 
-        parent::__construct(false);
+        parent::__construct(self::getFullName(...$types), false);
 
         $this->types = $types;
     }
@@ -45,24 +61,6 @@ final class IntersectionType extends Type
         }
 
         return true;
-    }
-
-    public function asString(): string
-    {
-        return $this->name();
-    }
-
-    public function name(): string
-    {
-        $types = [];
-
-        foreach ($this->types as $type) {
-            $types[] = $type->name();
-        }
-
-        sort($types);
-
-        return implode('&', $types);
     }
 
     /**

--- a/src/type/IntersectionType.php
+++ b/src/type/IntersectionType.php
@@ -115,7 +115,7 @@ final class IntersectionType extends Type
         foreach ($types as $type) {
             assert($type instanceof ObjectType);
 
-            $classQualifiedName = $type->className()->qualifiedName();
+            $classQualifiedName = $type->className->qualifiedName();
 
             if (in_array($classQualifiedName, $names, true)) {
                 throw new RuntimeException('An intersection type must not contain duplicate types');

--- a/src/type/IntersectionType.php
+++ b/src/type/IntersectionType.php
@@ -18,7 +18,7 @@ use function sort;
 final class IntersectionType extends Type
 {
     /**
-     * @psalm-var non-empty-list<Type>
+     * @psalm-var non-empty-list<ObjectType>
      */
     private array $types;
 
@@ -38,7 +38,13 @@ final class IntersectionType extends Type
 
     public function isAssignable(Type $other): bool
     {
-        return $other->isObject();
+        foreach ($this->types as $type) {
+            if (!$type->isAssignable($other)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function asString(): string
@@ -68,7 +74,7 @@ final class IntersectionType extends Type
     }
 
     /**
-     * @psalm-return non-empty-list<Type>
+     * @psalm-return non-empty-list<ObjectType>
      */
     public function types(): array
     {

--- a/src/type/IterableType.php
+++ b/src/type/IterableType.php
@@ -35,7 +35,7 @@ final class IterableType extends Type
         }
 
         if ($other instanceof SimpleType) {
-            return is_iterable($other->value());
+            return is_iterable($other->value);
         }
 
         if ($other instanceof ObjectType) {

--- a/src/type/IterableType.php
+++ b/src/type/IterableType.php
@@ -16,13 +16,6 @@ use ReflectionClass;
 
 final class IterableType extends Type
 {
-    private bool $allowsNull;
-
-    public function __construct(bool $nullable)
-    {
-        $this->allowsNull = $nullable;
-    }
-
     /**
      * @throws RuntimeException
      */
@@ -54,11 +47,6 @@ final class IterableType extends Type
     public function name(): string
     {
         return 'iterable';
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     /**

--- a/src/type/IterableType.php
+++ b/src/type/IterableType.php
@@ -39,7 +39,7 @@ final class IterableType extends Type
         }
 
         if ($other instanceof ObjectType) {
-            $className = $other->className()->qualifiedName();
+            $className = $other->className->qualifiedName();
 
             assert(class_exists($className));
 

--- a/src/type/IterableType.php
+++ b/src/type/IterableType.php
@@ -16,6 +16,11 @@ use ReflectionClass;
 
 final class IterableType extends Type
 {
+    public function __construct(bool $allowsNull)
+    {
+        parent::__construct('iterable', $allowsNull);
+    }
+
     /**
      * @throws RuntimeException
      */
@@ -42,11 +47,6 @@ final class IterableType extends Type
         }
 
         return false;
-    }
-
-    public function name(): string
-    {
-        return 'iterable';
     }
 
     /**

--- a/src/type/MixedType.php
+++ b/src/type/MixedType.php
@@ -13,7 +13,7 @@ final class MixedType extends Type
 {
     public function __construct()
     {
-        parent::__construct(true);
+        parent::__construct('mixed', true);
     }
 
     public function isAssignable(Type $other): bool
@@ -22,11 +22,6 @@ final class MixedType extends Type
     }
 
     public function asString(): string
-    {
-        return 'mixed';
-    }
-
-    public function name(): string
     {
         return 'mixed';
     }

--- a/src/type/MixedType.php
+++ b/src/type/MixedType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class MixedType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+
     public function isAssignable(Type $other): bool
     {
         return !$other instanceof VoidType;
@@ -24,11 +29,6 @@ final class MixedType extends Type
     public function name(): string
     {
         return 'mixed';
-    }
-
-    public function allowsNull(): bool
-    {
-        return true;
     }
 
     /**

--- a/src/type/NeverType.php
+++ b/src/type/NeverType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class NeverType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(false);
+    }
+
     public function isAssignable(Type $other): bool
     {
         return $other instanceof self;
@@ -19,11 +24,6 @@ final class NeverType extends Type
     public function name(): string
     {
         return 'never';
-    }
-
-    public function allowsNull(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/type/NeverType.php
+++ b/src/type/NeverType.php
@@ -13,17 +13,12 @@ final class NeverType extends Type
 {
     public function __construct()
     {
-        parent::__construct(false);
+        parent::__construct('never', false);
     }
 
     public function isAssignable(Type $other): bool
     {
         return $other instanceof self;
-    }
-
-    public function name(): string
-    {
-        return 'never';
     }
 
     /**

--- a/src/type/NullType.php
+++ b/src/type/NullType.php
@@ -13,17 +13,12 @@ final class NullType extends Type
 {
     public function __construct()
     {
-        parent::__construct(true);
+        parent::__construct('null', true);
     }
 
     public function isAssignable(Type $other): bool
     {
         return !($other instanceof VoidType);
-    }
-
-    public function name(): string
-    {
-        return 'null';
     }
 
     public function asString(): string

--- a/src/type/NullType.php
+++ b/src/type/NullType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class NullType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+
     public function isAssignable(Type $other): bool
     {
         return !($other instanceof VoidType);
@@ -24,11 +29,6 @@ final class NullType extends Type
     public function asString(): string
     {
         return 'null';
-    }
-
-    public function allowsNull(): bool
-    {
-        return true;
     }
 
     /**

--- a/src/type/ObjectType.php
+++ b/src/type/ObjectType.php
@@ -18,7 +18,7 @@ final class ObjectType extends Type
 
     public function __construct(TypeName $className, bool $allowsNull)
     {
-        parent::__construct($allowsNull);
+        parent::__construct($className->qualifiedName(), $allowsNull);
 
         $this->className  = $className;
     }
@@ -40,11 +40,6 @@ final class ObjectType extends Type
         }
 
         return false;
-    }
-
-    public function name(): string
-    {
-        return $this->className->qualifiedName();
     }
 
     public function className(): TypeName

--- a/src/type/ObjectType.php
+++ b/src/type/ObjectType.php
@@ -14,8 +14,6 @@ use function strcasecmp;
 
 final class ObjectType extends Type
 {
-    private TypeName $className;
-
     /**
      * Checks if $maybeParent is the same as $maybeChild, or a parent of $maybeChild.
      */
@@ -32,11 +30,9 @@ final class ObjectType extends Type
         return false;
     }
 
-    public function __construct(TypeName $className, bool $allowsNull)
+    public function __construct(public readonly TypeName $className, bool $allowsNull)
     {
         parent::__construct($className->qualifiedName(), $allowsNull);
-
-        $this->className = $className;
     }
 
     public function isAssignable(Type $other): bool
@@ -50,11 +46,6 @@ final class ObjectType extends Type
         }
 
         return self::isSameOrParentClass($this->className, $other->className);
-    }
-
-    public function className(): TypeName
-    {
-        return $this->className;
     }
 
     /**

--- a/src/type/ObjectType.php
+++ b/src/type/ObjectType.php
@@ -15,12 +15,12 @@ use function strcasecmp;
 final class ObjectType extends Type
 {
     private TypeName $className;
-    private bool $allowsNull;
 
     public function __construct(TypeName $className, bool $allowsNull)
     {
+        parent::__construct($allowsNull);
+
         $this->className  = $className;
-        $this->allowsNull = $allowsNull;
     }
 
     public function isAssignable(Type $other): bool
@@ -45,11 +45,6 @@ final class ObjectType extends Type
     public function name(): string
     {
         return $this->className->qualifiedName();
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     public function className(): TypeName

--- a/src/type/ObjectType.php
+++ b/src/type/ObjectType.php
@@ -16,11 +16,27 @@ final class ObjectType extends Type
 {
     private TypeName $className;
 
+    /**
+     * Checks if $maybeParent is the same as $maybeChild, or a parent of $maybeChild.
+     */
+    public static function isSameOrParentClass(TypeName $maybeParent, TypeName $maybeChild): bool
+    {
+        if (0 === strcasecmp($maybeParent->qualifiedName(), $maybeChild->qualifiedName())) {
+            return true;
+        }
+
+        if (is_subclass_of($maybeChild->qualifiedName(), $maybeParent->qualifiedName(), true)) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function __construct(TypeName $className, bool $allowsNull)
     {
         parent::__construct($className->qualifiedName(), $allowsNull);
 
-        $this->className  = $className;
+        $this->className = $className;
     }
 
     public function isAssignable(Type $other): bool
@@ -29,17 +45,11 @@ final class ObjectType extends Type
             return true;
         }
 
-        if ($other instanceof self) {
-            if (0 === strcasecmp($this->className->qualifiedName(), $other->className->qualifiedName())) {
-                return true;
-            }
-
-            if (is_subclass_of($other->className->qualifiedName(), $this->className->qualifiedName(), true)) {
-                return true;
-            }
+        if (!$other instanceof self) {
+            return false;
         }
 
-        return false;
+        return self::isSameOrParentClass($this->className, $other->className);
     }
 
     public function className(): TypeName

--- a/src/type/SimpleType.php
+++ b/src/type/SimpleType.php
@@ -13,13 +13,9 @@ use function strtolower;
 
 final class SimpleType extends Type
 {
-    private mixed $value;
-
-    public function __construct(string $name, bool $allowsNull, mixed $value = null)
+    public function __construct(string $name, bool $allowsNull, public readonly mixed $value = null)
     {
         parent::__construct($this->normalize($name), $allowsNull);
-
-        $this->value = $value;
     }
 
     public function isAssignable(Type $other): bool
@@ -41,11 +37,6 @@ final class SimpleType extends Type
         }
 
         return false;
-    }
-
-    public function value(): mixed
-    {
-        return $this->value;
     }
 
     /**

--- a/src/type/SimpleType.php
+++ b/src/type/SimpleType.php
@@ -13,14 +13,12 @@ use function strtolower;
 
 final class SimpleType extends Type
 {
-    private string $name;
     private mixed $value;
 
     public function __construct(string $name, bool $allowsNull, mixed $value = null)
     {
-        parent::__construct($allowsNull);
+        parent::__construct($this->normalize($name), $allowsNull);
 
-        $this->name  = $this->normalize($name);
         $this->value = $value;
     }
 
@@ -30,11 +28,11 @@ final class SimpleType extends Type
             return true;
         }
 
-        if ($this->name === 'bool' && $other->name() === 'true') {
+        if ($this->name === 'bool' && $other->name === 'true') {
             return true;
         }
 
-        if ($this->name === 'bool' && $other->name() === 'false') {
+        if ($this->name === 'bool' && $other->name === 'false') {
             return true;
         }
 
@@ -43,11 +41,6 @@ final class SimpleType extends Type
         }
 
         return false;
-    }
-
-    public function name(): string
-    {
-        return $this->name;
     }
 
     public function value(): mixed

--- a/src/type/SimpleType.php
+++ b/src/type/SimpleType.php
@@ -14,14 +14,14 @@ use function strtolower;
 final class SimpleType extends Type
 {
     private string $name;
-    private bool $allowsNull;
     private mixed $value;
 
-    public function __construct(string $name, bool $nullable, mixed $value = null)
+    public function __construct(string $name, bool $allowsNull, mixed $value = null)
     {
-        $this->name       = $this->normalize($name);
-        $this->allowsNull = $nullable;
-        $this->value      = $value;
+        parent::__construct($allowsNull);
+
+        $this->name  = $this->normalize($name);
+        $this->value = $value;
     }
 
     public function isAssignable(Type $other): bool
@@ -48,11 +48,6 @@ final class SimpleType extends Type
     public function name(): string
     {
         return $this->name;
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     public function value(): mixed

--- a/src/type/StaticType.php
+++ b/src/type/StaticType.php
@@ -15,9 +15,9 @@ final class StaticType extends Type
 
     public function __construct(TypeName $className, bool $allowsNull)
     {
-        parent::__construct($allowsNull);
+        parent::__construct('static', $allowsNull);
 
-        $this->className  = $className;
+        $this->className = $className;
     }
 
     public function isAssignable(Type $other): bool
@@ -39,11 +39,6 @@ final class StaticType extends Type
         }
 
         return false;
-    }
-
-    public function name(): string
-    {
-        return 'static';
     }
 
     /**

--- a/src/type/StaticType.php
+++ b/src/type/StaticType.php
@@ -12,12 +12,12 @@ namespace SebastianBergmann\Type;
 final class StaticType extends Type
 {
     private TypeName $className;
-    private bool $allowsNull;
 
     public function __construct(TypeName $className, bool $allowsNull)
     {
+        parent::__construct($allowsNull);
+
         $this->className  = $className;
-        $this->allowsNull = $allowsNull;
     }
 
     public function isAssignable(Type $other): bool
@@ -44,11 +44,6 @@ final class StaticType extends Type
     public function name(): string
     {
         return 'static';
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     /**

--- a/src/type/StaticType.php
+++ b/src/type/StaticType.php
@@ -30,15 +30,7 @@ final class StaticType extends Type
             return false;
         }
 
-        if (0 === strcasecmp($this->className->qualifiedName(), $other->className()->qualifiedName())) {
-            return true;
-        }
-
-        if (is_subclass_of($other->className()->qualifiedName(), $this->className->qualifiedName(), true)) {
-            return true;
-        }
-
-        return false;
+        return ObjectType::isSameOrParentClass($this->className, $other->className());
     }
 
     /**

--- a/src/type/StaticType.php
+++ b/src/type/StaticType.php
@@ -11,13 +11,9 @@ namespace SebastianBergmann\Type;
 
 final class StaticType extends Type
 {
-    private TypeName $className;
-
-    public function __construct(TypeName $className, bool $allowsNull)
+    public function __construct(public readonly TypeName $className, bool $allowsNull)
     {
         parent::__construct('static', $allowsNull);
-
-        $this->className = $className;
     }
 
     public function isAssignable(Type $other): bool
@@ -30,7 +26,7 @@ final class StaticType extends Type
             return false;
         }
 
-        return ObjectType::isSameOrParentClass($this->className, $other->className());
+        return ObjectType::isSameOrParentClass($this->className, $other->className);
     }
 
     /**

--- a/src/type/TrueType.php
+++ b/src/type/TrueType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class TrueType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(false);
+    }
+
     public function isAssignable(Type $other): bool
     {
         if ($other instanceof self) {
@@ -25,11 +30,6 @@ final class TrueType extends Type
     public function name(): string
     {
         return 'true';
-    }
-
-    public function allowsNull(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/type/TrueType.php
+++ b/src/type/TrueType.php
@@ -24,7 +24,7 @@ final class TrueType extends Type
 
         return $other instanceof SimpleType &&
               $other->name === 'bool' &&
-              $other->value() === true;
+              $other->value === true;
     }
 
     /**

--- a/src/type/TrueType.php
+++ b/src/type/TrueType.php
@@ -13,7 +13,7 @@ final class TrueType extends Type
 {
     public function __construct()
     {
-        parent::__construct(false);
+        parent::__construct('true', false);
     }
 
     public function isAssignable(Type $other): bool
@@ -23,13 +23,8 @@ final class TrueType extends Type
         }
 
         return $other instanceof SimpleType &&
-              $other->name() === 'bool' &&
+              $other->name === 'bool' &&
               $other->value() === true;
-    }
-
-    public function name(): string
-    {
-        return 'true';
     }
 
     /**

--- a/src/type/Type.php
+++ b/src/type/Type.php
@@ -60,9 +60,11 @@ abstract class Type
         };
     }
 
+    public function __construct(public readonly bool $allowsNull) {}
+
     public function asString(): string
     {
-        return ($this->allowsNull() ? '?' : '') . $this->name();
+        return ($this->allowsNull ? '?' : '') . $this->name();
     }
 
     /**
@@ -188,6 +190,4 @@ abstract class Type
     abstract public function isAssignable(self $other): bool;
 
     abstract public function name(): string;
-
-    abstract public function allowsNull(): bool;
 }

--- a/src/type/Type.php
+++ b/src/type/Type.php
@@ -60,11 +60,11 @@ abstract class Type
         };
     }
 
-    public function __construct(public readonly bool $allowsNull) {}
+    public function __construct(public readonly string $name, public readonly bool $allowsNull) {}
 
     public function asString(): string
     {
-        return ($this->allowsNull ? '?' : '') . $this->name();
+        return ($this->allowsNull ? '?' : '') . $this->name;
     }
 
     /**
@@ -188,6 +188,4 @@ abstract class Type
     }
 
     abstract public function isAssignable(self $other): bool;
-
-    abstract public function name(): string;
 }

--- a/src/type/UnionType.php
+++ b/src/type/UnionType.php
@@ -20,6 +20,24 @@ final class UnionType extends Type
      */
     private array $types;
 
+    public static function getFullName(Type ...$types): string
+    {
+        $names = [];
+
+        foreach ($types as $type) {
+            if ($type->isIntersection()) {
+                // Support for PHP 8.2 Disjunctive Normal Form types.
+                $names[] = '(' . $type->name . ')';
+            } else {
+                $names[] = $type->name;
+            }
+        }
+
+        sort($names);
+
+        return implode('|', $names);
+    }
+
     /**
      * @throws RuntimeException
      */
@@ -28,7 +46,7 @@ final class UnionType extends Type
         $this->ensureMinimumOfTwoTypes(...$types);
         $this->ensureOnlyValidTypes(...$types);
 
-        parent::__construct(self::isAnyTypeNull(...$types));
+        parent::__construct(self::getFullName(...$types), self::isAnyTypeNull(...$types));
 
         $this->types = $types;
     }
@@ -42,30 +60,6 @@ final class UnionType extends Type
         }
 
         return false;
-    }
-
-    public function asString(): string
-    {
-        return $this->name();
-    }
-
-    public function name(): string
-    {
-        $types = [];
-
-        foreach ($this->types as $type) {
-            if ($type->isIntersection()) {
-                $types[] = '(' . $type->name() . ')';
-
-                continue;
-            }
-
-            $types[] = $type->name();
-        }
-
-        sort($types);
-
-        return implode('|', $types);
     }
 
     /**

--- a/src/type/UnionType.php
+++ b/src/type/UnionType.php
@@ -28,6 +28,8 @@ final class UnionType extends Type
         $this->ensureMinimumOfTwoTypes(...$types);
         $this->ensureOnlyValidTypes(...$types);
 
+        parent::__construct(self::isAnyTypeNull(...$types));
+
         $this->types = $types;
     }
 
@@ -64,17 +66,6 @@ final class UnionType extends Type
         sort($types);
 
         return implode('|', $types);
-    }
-
-    public function allowsNull(): bool
-    {
-        foreach ($this->types as $type) {
-            if ($type instanceof NullType) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -134,5 +125,16 @@ final class UnionType extends Type
                 );
             }
         }
+    }
+
+    private static function isAnyTypeNull(Type ...$types): bool
+    {
+        foreach ($types as $type) {
+            if ($type instanceof NullType) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/type/UnknownType.php
+++ b/src/type/UnknownType.php
@@ -13,17 +13,12 @@ final class UnknownType extends Type
 {
     public function __construct()
     {
-        parent::__construct(true);
+        parent::__construct('unknown type', true);
     }
 
     public function isAssignable(Type $other): bool
     {
         return true;
-    }
-
-    public function name(): string
-    {
-        return 'unknown type';
     }
 
     public function asString(): string

--- a/src/type/UnknownType.php
+++ b/src/type/UnknownType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class UnknownType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+
     public function isAssignable(Type $other): bool
     {
         return true;
@@ -24,11 +29,6 @@ final class UnknownType extends Type
     public function asString(): string
     {
         return '';
-    }
-
-    public function allowsNull(): bool
-    {
-        return true;
     }
 
     /**

--- a/src/type/VoidType.php
+++ b/src/type/VoidType.php
@@ -11,6 +11,11 @@ namespace SebastianBergmann\Type;
 
 final class VoidType extends Type
 {
+    public function __construct()
+    {
+        parent::__construct(false);
+    }
+
     public function isAssignable(Type $other): bool
     {
         return $other instanceof self;
@@ -19,11 +24,6 @@ final class VoidType extends Type
     public function name(): string
     {
         return 'void';
-    }
-
-    public function allowsNull(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/type/VoidType.php
+++ b/src/type/VoidType.php
@@ -13,17 +13,12 @@ final class VoidType extends Type
 {
     public function __construct()
     {
-        parent::__construct(false);
+        parent::__construct('void', false);
     }
 
     public function isAssignable(Type $other): bool
     {
         return $other instanceof self;
-    }
-
-    public function name(): string
-    {
-        return 'void';
     }
 
     /**

--- a/tests/unit/ParameterTest.php
+++ b/tests/unit/ParameterTest.php
@@ -24,7 +24,7 @@ final class ParameterTest extends TestCase
     {
         $parameter = new Parameter('name', Type::fromValue(1, false));
 
-        $this->assertSame('name', $parameter->name());
+        $this->assertSame('name', $parameter->name);
     }
 
     public function testHasType(): void
@@ -32,6 +32,6 @@ final class ParameterTest extends TestCase
         $type      = Type::fromValue(1, false);
         $parameter = new Parameter('name', $type);
 
-        $this->assertSame($type, $parameter->type());
+        $this->assertSame($type, $parameter->type);
     }
 }

--- a/tests/unit/ReflectionMapperTest.php
+++ b/tests/unit/ReflectionMapperTest.php
@@ -58,7 +58,7 @@ final class ReflectionMapperTest extends TestCase
     #[DataProvider('typeProvider')]
     public function testMapsFromReturnType(string $expected, ReflectionFunction|ReflectionMethod $method): void
     {
-        $this->assertSame($expected, (new ReflectionMapper)->fromReturnType($method)->name());
+        $this->assertSame($expected, (new ReflectionMapper)->fromReturnType($method)->name);
     }
 
     public function testMapsFromIntersectionReturnType(): void
@@ -66,7 +66,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresIntersectionReturnType::class, 'returnsObjectThatImplementsAnInterfaceAndAnotherInterface'));
 
         $this->assertInstanceOf(IntersectionType::class, $type);
-        $this->assertSame(AnInterface::class . '&' . AnotherInterface::class, $type->name());
+        $this->assertSame(AnInterface::class . '&' . AnotherInterface::class, $type->name);
     }
 
     public function testMapsFromUnionReturnType(): void
@@ -74,7 +74,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareUnionReturnTypes::class, 'returnsBoolOrInt'));
 
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame('bool|int', $type->name());
+        $this->assertSame('bool|int', $type->name);
     }
 
     public function testMapsFromUnionReturnTypeWithSelf(): void
@@ -82,7 +82,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareUnionReturnTypes::class, 'returnsSelfOrStdClass'));
 
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame(ClassWithMethodsThatDeclareUnionReturnTypes::class . '|stdClass', $type->name());
+        $this->assertSame(ClassWithMethodsThatDeclareUnionReturnTypes::class . '|stdClass', $type->name);
     }
 
     public function testMapsFromMixedReturnType(): void
@@ -90,7 +90,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareUnionReturnTypes::class, 'returnsMixed'));
 
         $this->assertInstanceOf(MixedType::class, $type);
-        $this->assertSame('mixed', $type->name());
+        $this->assertSame('mixed', $type->name);
     }
 
     public function testMapsFromStaticReturnType(): void
@@ -116,7 +116,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatHaveStaticReturnTypes::class, 'returnsUnionWithStatic'));
 
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame('static|stdClass', $type->name());
+        $this->assertSame('static|stdClass', $type->name);
     }
 
     public function testMapsFromUnionReturnTypeWithIntOrFalse(): void
@@ -124,7 +124,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareUnionReturnTypes::class, 'returnsIntOrFalse'));
 
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame('false|int', $type->name());
+        $this->assertSame('false|int', $type->name);
     }
 
     public function testMapsFromNeverReturnType(): void
@@ -132,7 +132,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresNeverReturnType::class, 'neverReturnType'));
 
         $this->assertInstanceOf(NeverType::class, $type);
-        $this->assertSame('never', $type->name());
+        $this->assertSame('never', $type->name);
     }
 
     #[RequiresPhp('>= 8.2')]
@@ -141,7 +141,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresTrueReturnType::class, 'trueReturnType'));
 
         $this->assertInstanceOf(TrueType::class, $type);
-        $this->assertSame('true', $type->name());
+        $this->assertSame('true', $type->name);
     }
 
     #[RequiresPhp('>= 8.2')]
@@ -150,7 +150,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresFalseReturnType::class, 'falseReturnType'));
 
         $this->assertInstanceOf(FalseType::class, $type);
-        $this->assertSame('false', $type->name());
+        $this->assertSame('false', $type->name);
     }
 
     #[RequiresPhp('>= 8.2')]
@@ -159,7 +159,7 @@ final class ReflectionMapperTest extends TestCase
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodThatDeclaresNullReturnType::class, 'nullReturnType'));
 
         $this->assertInstanceOf(NullType::class, $type);
-        $this->assertSame('null', $type->name());
+        $this->assertSame('null', $type->name);
     }
 
     #[RequiresPhp('>= 8.2')]
@@ -167,15 +167,15 @@ final class ReflectionMapperTest extends TestCase
     {
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareDisjunctiveNormalFormReturnTypes::class, 'one'));
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B)|SebastianBergmann\Type\TestFixture\D', $type->name());
+        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B)|SebastianBergmann\Type\TestFixture\D', $type->name);
 
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareDisjunctiveNormalFormReturnTypes::class, 'two'));
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame('(SebastianBergmann\Type\TestFixture\D&SebastianBergmann\Type\TestFixture\X)|SebastianBergmann\Type\TestFixture\C|null', $type->name());
+        $this->assertSame('(SebastianBergmann\Type\TestFixture\D&SebastianBergmann\Type\TestFixture\X)|SebastianBergmann\Type\TestFixture\C|null', $type->name);
 
         $type = (new ReflectionMapper)->fromReturnType(new ReflectionMethod(ClassWithMethodsThatDeclareDisjunctiveNormalFormReturnTypes::class, 'three'));
         $this->assertInstanceOf(UnionType::class, $type);
-        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B&SebastianBergmann\Type\TestFixture\D)|int|null', $type->name());
+        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B&SebastianBergmann\Type\TestFixture\D)|int|null', $type->name);
     }
 
     public function testMapsFromParameters(): void

--- a/tests/unit/ReflectionMapperTest.php
+++ b/tests/unit/ReflectionMapperTest.php
@@ -99,7 +99,7 @@ final class ReflectionMapperTest extends TestCase
 
         $this->assertInstanceOf(StaticType::class, $type);
         $this->assertSame('static', $type->asString());
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     public function testMapsFromNullableStaticReturnType(): void
@@ -108,7 +108,7 @@ final class ReflectionMapperTest extends TestCase
 
         $this->assertInstanceOf(StaticType::class, $type);
         $this->assertSame('?static', $type->asString());
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     public function testMapsFromUnionWithStaticReturnType(): void

--- a/tests/unit/ReflectionMapperTest.php
+++ b/tests/unit/ReflectionMapperTest.php
@@ -184,15 +184,15 @@ final class ReflectionMapperTest extends TestCase
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('', $types[0]->type->asString());
 
         $method = new ReflectionMethod(ClassWithMethodsThatDeclareParameterTypes::class, 'named');
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('SebastianBergmann\Type\TestFixture\A', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('SebastianBergmann\Type\TestFixture\A', $types[0]->type->asString());
     }
 
     public function testMapsFromUnionTypeParameters(): void
@@ -201,8 +201,8 @@ final class ReflectionMapperTest extends TestCase
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('bool|int', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('bool|int', $types[0]->type->asString());
     }
 
     public function testMapsFromIntersectionTypeParameters(): void
@@ -211,8 +211,8 @@ final class ReflectionMapperTest extends TestCase
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B', $types[0]->type->asString());
     }
 
     #[RequiresPhp('>= 8.2')]
@@ -222,22 +222,22 @@ final class ReflectionMapperTest extends TestCase
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B)|SebastianBergmann\Type\TestFixture\D', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B)|SebastianBergmann\Type\TestFixture\D', $types[0]->type->asString());
 
         $method = new ReflectionMethod(ClassWithMethodsThatDeclareDisjunctiveNormalFormParameterTypes::class, 'dnfTwo');
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('(SebastianBergmann\Type\TestFixture\D&SebastianBergmann\Type\TestFixture\X)|SebastianBergmann\Type\TestFixture\C|null', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('(SebastianBergmann\Type\TestFixture\D&SebastianBergmann\Type\TestFixture\X)|SebastianBergmann\Type\TestFixture\C|null', $types[0]->type->asString());
 
         $method = new ReflectionMethod(ClassWithMethodsThatDeclareDisjunctiveNormalFormParameterTypes::class, 'dnfThree');
         $types  = (new ReflectionMapper)->fromParameterTypes($method);
 
         $this->assertCount(1, $types);
-        $this->assertSame('x', $types[0]->name());
-        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B&SebastianBergmann\Type\TestFixture\D)|int|null', $types[0]->type()->asString());
+        $this->assertSame('x', $types[0]->name);
+        $this->assertSame('(SebastianBergmann\Type\TestFixture\A&SebastianBergmann\Type\TestFixture\B&SebastianBergmann\Type\TestFixture\D)|int|null', $types[0]->type->asString());
     }
 
     public function typeProvider(): array

--- a/tests/unit/TypeNameTest.php
+++ b/tests/unit/TypeNameTest.php
@@ -24,9 +24,9 @@ final class TypeNameTest extends TestCase
         $typeName = TypeName::fromReflection($class);
 
         $this->assertTrue($typeName->isNamespaced());
-        $this->assertSame('SebastianBergmann\\Type', $typeName->namespaceName());
+        $this->assertSame('SebastianBergmann\\Type', $typeName->namespaceName);
         $this->assertSame(TypeName::class, $typeName->qualifiedName());
-        $this->assertSame('TypeName', $typeName->simpleName());
+        $this->assertSame('TypeName', $typeName->simpleName);
     }
 
     public function testFromQualifiedName(): void
@@ -34,9 +34,9 @@ final class TypeNameTest extends TestCase
         $typeName = TypeName::fromQualifiedName('PHPUnit\\Framework\\MockObject\\TypeName');
 
         $this->assertTrue($typeName->isNamespaced());
-        $this->assertSame('PHPUnit\\Framework\\MockObject', $typeName->namespaceName());
+        $this->assertSame('PHPUnit\\Framework\\MockObject', $typeName->namespaceName);
         $this->assertSame('PHPUnit\\Framework\\MockObject\\TypeName', $typeName->qualifiedName());
-        $this->assertSame('TypeName', $typeName->simpleName());
+        $this->assertSame('TypeName', $typeName->simpleName);
     }
 
     public function testFromQualifiedNameWithLeadingSeparator(): void
@@ -44,9 +44,9 @@ final class TypeNameTest extends TestCase
         $typeName = TypeName::fromQualifiedName('\\Foo\\Bar');
 
         $this->assertTrue($typeName->isNamespaced());
-        $this->assertSame('Foo', $typeName->namespaceName());
+        $this->assertSame('Foo', $typeName->namespaceName);
         $this->assertSame('Foo\\Bar', $typeName->qualifiedName());
-        $this->assertSame('Bar', $typeName->simpleName());
+        $this->assertSame('Bar', $typeName->simpleName);
     }
 
     public function testFromQualifiedNameWithoutNamespace(): void
@@ -54,8 +54,8 @@ final class TypeNameTest extends TestCase
         $typeName = TypeName::fromQualifiedName('Bar');
 
         $this->assertFalse($typeName->isNamespaced());
-        $this->assertNull($typeName->namespaceName());
+        $this->assertNull($typeName->namespaceName);
         $this->assertSame('Bar', $typeName->qualifiedName());
-        $this->assertSame('Bar', $typeName->simpleName());
+        $this->assertSame('Bar', $typeName->simpleName);
     }
 }

--- a/tests/unit/type/CallableTypeTest.php
+++ b/tests/unit/type/CallableTypeTest.php
@@ -34,7 +34,7 @@ final class CallableTypeTest extends TestCase
 
     public function testHasName(): void
     {
-        $this->assertSame('callable', $this->type->name());
+        $this->assertSame('callable', $this->type->name);
     }
 
     public function testMayDisallowNull(): void

--- a/tests/unit/type/CallableTypeTest.php
+++ b/tests/unit/type/CallableTypeTest.php
@@ -39,14 +39,14 @@ final class CallableTypeTest extends TestCase
 
     public function testMayDisallowNull(): void
     {
-        $this->assertFalse($this->type->allowsNull());
+        $this->assertFalse($this->type->allowsNull);
     }
 
     public function testMayAllowNull(): void
     {
         $type = new CallableType(true);
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     public function testNullCanBeAssignedToNullableCallable(): void

--- a/tests/unit/type/FalseTypeTest.php
+++ b/tests/unit/type/FalseTypeTest.php
@@ -23,7 +23,7 @@ final class FalseTypeTest extends TestCase
 {
     public function testHasName(): void
     {
-        $this->assertSame('false', (new FalseType)->name());
+        $this->assertSame('false', (new FalseType)->name);
     }
 
     #[DataProvider('assignableTypes')]

--- a/tests/unit/type/FalseTypeTest.php
+++ b/tests/unit/type/FalseTypeTest.php
@@ -66,7 +66,7 @@ final class FalseTypeTest extends TestCase
     {
         $type = new FalseType;
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     public function testCanBeQueriedForType(): void

--- a/tests/unit/type/GenericObjectTypeTest.php
+++ b/tests/unit/type/GenericObjectTypeTest.php
@@ -32,7 +32,7 @@ final class GenericObjectTypeTest extends TestCase
 
     public function testHasName(): void
     {
-        $this->assertSame('object', $this->type->name());
+        $this->assertSame('object', $this->type->name);
     }
 
     public function testMayDisallowNull(): void

--- a/tests/unit/type/GenericObjectTypeTest.php
+++ b/tests/unit/type/GenericObjectTypeTest.php
@@ -37,14 +37,14 @@ final class GenericObjectTypeTest extends TestCase
 
     public function testMayDisallowNull(): void
     {
-        $this->assertFalse($this->type->allowsNull());
+        $this->assertFalse($this->type->allowsNull);
     }
 
     public function testMayAllowNull(): void
     {
         $type = new GenericObjectType(true);
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     public function testObjectCanBeAssignedToGenericObject(): void

--- a/tests/unit/type/IntersectionTypeTest.php
+++ b/tests/unit/type/IntersectionTypeTest.php
@@ -70,7 +70,7 @@ final class IntersectionTypeTest extends TestCase
     {
         $this->assertSame(
             AnInterface::class . '&' . AnotherInterface::class,
-            $this->type->name()
+            $this->type->name
         );
     }
 

--- a/tests/unit/type/IntersectionTypeTest.php
+++ b/tests/unit/type/IntersectionTypeTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Type\TestFixture\AnInterface;
 use SebastianBergmann\Type\TestFixture\AnotherInterface;
 use SebastianBergmann\Type\TestFixture\ClassImplementingAnInterfaceAndAnotherInterface;
+use stdClass;
 
 #[CoversClass(IntersectionType::class)]
 #[CoversClass(Type::class)]
@@ -111,6 +112,14 @@ final class IntersectionTypeTest extends TestCase
             [
                 false,
                 Type::fromValue(false, false),
+                new IntersectionType(
+                    Type::fromName(AnInterface::class, false),
+                    Type::fromName(AnotherInterface::class, false)
+                ),
+            ],
+            [
+                false,
+                Type::fromName(stdClass::class, false),
                 new IntersectionType(
                     Type::fromName(AnInterface::class, false),
                     Type::fromName(AnotherInterface::class, false)

--- a/tests/unit/type/IntersectionTypeTest.php
+++ b/tests/unit/type/IntersectionTypeTest.php
@@ -121,7 +121,7 @@ final class IntersectionTypeTest extends TestCase
 
     public function testDoesNotAllowNull(): void
     {
-        $this->assertFalse($this->type->allowsNull());
+        $this->assertFalse($this->type->allowsNull);
     }
 
     public function testCannotBeCreatedFromLessThanTwoTypes(): void

--- a/tests/unit/type/IterableTypeTest.php
+++ b/tests/unit/type/IterableTypeTest.php
@@ -37,14 +37,14 @@ final class IterableTypeTest extends TestCase
 
     public function testMayDisallowNull(): void
     {
-        $this->assertFalse($this->type->allowsNull());
+        $this->assertFalse($this->type->allowsNull);
     }
 
     public function testMayAllowNull(): void
     {
         $type = new IterableType(true);
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     public function testNullCanBeAssignedToNullableIterable(): void

--- a/tests/unit/type/IterableTypeTest.php
+++ b/tests/unit/type/IterableTypeTest.php
@@ -32,7 +32,7 @@ final class IterableTypeTest extends TestCase
 
     public function testHasName(): void
     {
-        $this->assertSame('iterable', $this->type->name());
+        $this->assertSame('iterable', $this->type->name);
     }
 
     public function testMayDisallowNull(): void

--- a/tests/unit/type/MixedTypeTest.php
+++ b/tests/unit/type/MixedTypeTest.php
@@ -28,7 +28,7 @@ final class MixedTypeTest extends TestCase
     {
         $type = new MixedType;
 
-        $this->assertSame('mixed', $type->name());
+        $this->assertSame('mixed', $type->name);
     }
 
     public function testCanBeRepresentedAsString(): void

--- a/tests/unit/type/MixedTypeTest.php
+++ b/tests/unit/type/MixedTypeTest.php
@@ -42,7 +42,7 @@ final class MixedTypeTest extends TestCase
     {
         $type = new MixedType;
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     #[DataProvider('assignableTypes')]

--- a/tests/unit/type/NeverTypeTest.php
+++ b/tests/unit/type/NeverTypeTest.php
@@ -21,7 +21,7 @@ final class NeverTypeTest extends TestCase
 {
     public function testHasName(): void
     {
-        $this->assertSame('never', (new NeverType)->name());
+        $this->assertSame('never', (new NeverType)->name);
     }
 
     #[DataProvider('assignableTypes')]

--- a/tests/unit/type/NeverTypeTest.php
+++ b/tests/unit/type/NeverTypeTest.php
@@ -62,7 +62,7 @@ final class NeverTypeTest extends TestCase
     {
         $type = new NeverType;
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     public function testCanBeQueriedForType(): void

--- a/tests/unit/type/NullTypeTest.php
+++ b/tests/unit/type/NullTypeTest.php
@@ -58,7 +58,7 @@ final class NullTypeTest extends TestCase
 
     public function testAllowsNull(): void
     {
-        $this->assertTrue($this->type->allowsNull());
+        $this->assertTrue($this->type->allowsNull);
     }
 
     public function testHasName(): void

--- a/tests/unit/type/NullTypeTest.php
+++ b/tests/unit/type/NullTypeTest.php
@@ -63,7 +63,7 @@ final class NullTypeTest extends TestCase
 
     public function testHasName(): void
     {
-        $this->assertSame('null', $this->type->name());
+        $this->assertSame('null', $this->type->name);
     }
 
     public function testCanBeRepresentedAsString(): void

--- a/tests/unit/type/ObjectTypeTest.php
+++ b/tests/unit/type/ObjectTypeTest.php
@@ -42,7 +42,7 @@ final class ObjectTypeTest extends TestCase
 
     public function testHasName(): void
     {
-        $this->assertSame(ChildClass::class, $this->childClass->name());
+        $this->assertSame(ChildClass::class, $this->childClass->name);
     }
 
     public function testParentIsNotAssignableToChild(): void

--- a/tests/unit/type/ObjectTypeTest.php
+++ b/tests/unit/type/ObjectTypeTest.php
@@ -130,7 +130,7 @@ final class ObjectTypeTest extends TestCase
 
     public function testHasClassName(): void
     {
-        $this->assertSame('SebastianBergmann\Type\TestFixture\ParentClass', $this->parentClass->className()->qualifiedName());
+        $this->assertSame('SebastianBergmann\Type\TestFixture\ParentClass', $this->parentClass->className->qualifiedName());
     }
 
     public function testCanBeQueriedForType(): void

--- a/tests/unit/type/ObjectTypeTest.php
+++ b/tests/unit/type/ObjectTypeTest.php
@@ -115,7 +115,7 @@ final class ObjectTypeTest extends TestCase
             false
         );
 
-        $this->assertFalse($someClass->allowsNull());
+        $this->assertFalse($someClass->allowsNull);
     }
 
     public function testPreservesNullAllowed(): void
@@ -125,7 +125,7 @@ final class ObjectTypeTest extends TestCase
             true
         );
 
-        $this->assertTrue($someClass->allowsNull());
+        $this->assertTrue($someClass->allowsNull);
     }
 
     public function testHasClassName(): void

--- a/tests/unit/type/SimpleTypeTest.php
+++ b/tests/unit/type/SimpleTypeTest.php
@@ -31,63 +31,63 @@ final class SimpleTypeTest extends TestCase
     {
         $type = new SimpleType('bool', false);
 
-        $this->assertSame('bool', $type->name());
+        $this->assertSame('bool', $type->name);
     }
 
     public function testCanBeBoolean(): void
     {
         $type = new SimpleType('boolean', false);
 
-        $this->assertSame('bool', $type->name());
+        $this->assertSame('bool', $type->name);
     }
 
     public function testCanBeDouble(): void
     {
         $type = new SimpleType('double', false);
 
-        $this->assertSame('float', $type->name());
+        $this->assertSame('float', $type->name);
     }
 
     public function testCanBeFloat(): void
     {
         $type = new SimpleType('float', false);
 
-        $this->assertSame('float', $type->name());
+        $this->assertSame('float', $type->name);
     }
 
     public function testCanBeReal(): void
     {
         $type = new SimpleType('real', false);
 
-        $this->assertSame('float', $type->name());
+        $this->assertSame('float', $type->name);
     }
 
     public function testCanBeInt(): void
     {
         $type = new SimpleType('int', false);
 
-        $this->assertSame('int', $type->name());
+        $this->assertSame('int', $type->name);
     }
 
     public function testCanBeInteger(): void
     {
         $type = new SimpleType('integer', false);
 
-        $this->assertSame('int', $type->name());
+        $this->assertSame('int', $type->name);
     }
 
     public function testCanBeArray(): void
     {
         $type = new SimpleType('array', false);
 
-        $this->assertSame('array', $type->name());
+        $this->assertSame('array', $type->name);
     }
 
     public function testCanBeArray2(): void
     {
         $type = new SimpleType('[]', false);
 
-        $this->assertSame('array', $type->name());
+        $this->assertSame('array', $type->name);
     }
 
     public function testMayAllowNull(): void
@@ -170,6 +170,6 @@ final class SimpleTypeTest extends TestCase
     {
         $type = new SimpleType('BOOLEAN', false);
 
-        $this->assertSame('bool', $type->name());
+        $this->assertSame('bool', $type->name);
     }
 }

--- a/tests/unit/type/SimpleTypeTest.php
+++ b/tests/unit/type/SimpleTypeTest.php
@@ -142,7 +142,7 @@ final class SimpleTypeTest extends TestCase
 
     public function testCanHaveValue(): void
     {
-        $this->assertSame('string', Type::fromValue('string', false)->value());
+        $this->assertSame('string', Type::fromValue('string', false)->value);
     }
 
     public function testCanBeQueriedForType(): void

--- a/tests/unit/type/SimpleTypeTest.php
+++ b/tests/unit/type/SimpleTypeTest.php
@@ -94,14 +94,14 @@ final class SimpleTypeTest extends TestCase
     {
         $type = new SimpleType('bool', true);
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     public function testMayNotAllowNull(): void
     {
         $type = new SimpleType('bool', false);
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     #[DataProvider('assignablePairs')]

--- a/tests/unit/type/StaticTypeTest.php
+++ b/tests/unit/type/StaticTypeTest.php
@@ -42,7 +42,7 @@ final class StaticTypeTest extends TestCase
     {
         $type = new StaticType(TypeName::fromQualifiedName('vendor\project\foo'), false);
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
         $this->assertSame('static', $type->asString());
     }
 
@@ -50,7 +50,7 @@ final class StaticTypeTest extends TestCase
     {
         $type = new StaticType(TypeName::fromQualifiedName('vendor\project\foo'), true);
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
         $this->assertSame('?static', $type->asString());
     }
 

--- a/tests/unit/type/StaticTypeTest.php
+++ b/tests/unit/type/StaticTypeTest.php
@@ -28,7 +28,7 @@ final class StaticTypeTest extends TestCase
     {
         $type = new StaticType(TypeName::fromQualifiedName('vendor\project\foo'), false);
 
-        $this->assertSame('static', $type->name());
+        $this->assertSame('static', $type->name);
     }
 
     public function testCanBeRepresentedAsString(): void

--- a/tests/unit/type/TrueTypeTest.php
+++ b/tests/unit/type/TrueTypeTest.php
@@ -66,7 +66,7 @@ final class TrueTypeTest extends TestCase
     {
         $type = new TrueType;
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     public function testCanBeQueriedForType(): void

--- a/tests/unit/type/TrueTypeTest.php
+++ b/tests/unit/type/TrueTypeTest.php
@@ -23,7 +23,7 @@ final class TrueTypeTest extends TestCase
 {
     public function testHasName(): void
     {
-        $this->assertSame('true', (new TrueType)->name());
+        $this->assertSame('true', (new TrueType)->name);
     }
 
     #[DataProvider('assignableTypes')]

--- a/tests/unit/type/TypeTest.php
+++ b/tests/unit/type/TypeTest.php
@@ -61,7 +61,7 @@ final class TypeTest extends TestCase
             '?void'             => [new VoidType, 'void', true],
             'void'              => [new VoidType, 'void', false],
             '?null'             => [new NullType, 'null', true],
-            'null'              => [new NullType, 'null', true],
+            'null'              => [new NullType, 'null', false],
             '?int'              => [new SimpleType('int', true), 'int', true],
             '?integer'          => [new SimpleType('int', true), 'integer', true],
             'int'               => [new SimpleType('int', false), 'int', false],

--- a/tests/unit/type/TypeTest.php
+++ b/tests/unit/type/TypeTest.php
@@ -80,10 +80,10 @@ final class TypeTest extends TestCase
             'unknown type'      => [new UnknownType, 'unknown type', false],
             '?classname'        => [new ObjectType(TypeName::fromQualifiedName(stdClass::class), true), stdClass::class, true],
             'classname'         => [new ObjectType(TypeName::fromQualifiedName(stdClass::class), false), stdClass::class, false],
-            'callable'          => [new CallableType(false), 'callable', false],
             '?callable'         => [new CallableType(true), 'callable', true],
-            'iterable'          => [new IterableType(false), 'iterable', false],
+            'callable'          => [new CallableType(false), 'callable', false],
             '?iterable'         => [new IterableType(true), 'iterable', true],
+            'iterable'          => [new IterableType(false), 'iterable', false],
             'mixed'             => [new MixedType, 'mixed', false],
             'never'             => [new NeverType, 'never', false],
         ];

--- a/tests/unit/type/UnionTypeTest.php
+++ b/tests/unit/type/UnionTypeTest.php
@@ -72,7 +72,7 @@ final class UnionTypeTest extends TestCase
             Type::fromName('null', true)
         );
 
-        $this->assertTrue($type->allowsNull());
+        $this->assertTrue($type->allowsNull);
     }
 
     public function testMayNotAllowNull(): void
@@ -82,7 +82,7 @@ final class UnionTypeTest extends TestCase
             Type::fromName('int', false)
         );
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     public function testMayContainIntersectionType(): void

--- a/tests/unit/type/UnknownTypeTest.php
+++ b/tests/unit/type/UnknownTypeTest.php
@@ -46,7 +46,7 @@ final class UnknownTypeTest extends TestCase
 
     public function testAllowsNull(): void
     {
-        $this->assertTrue($this->type->allowsNull());
+        $this->assertTrue($this->type->allowsNull);
     }
 
     public function testHasName(): void

--- a/tests/unit/type/UnknownTypeTest.php
+++ b/tests/unit/type/UnknownTypeTest.php
@@ -51,7 +51,7 @@ final class UnknownTypeTest extends TestCase
 
     public function testHasName(): void
     {
-        $this->assertSame('unknown type', $this->type->name());
+        $this->assertSame('unknown type', $this->type->name);
     }
 
     public function testCanBeRepresentedAsString(): void

--- a/tests/unit/type/VoidTypeTest.php
+++ b/tests/unit/type/VoidTypeTest.php
@@ -62,7 +62,7 @@ final class VoidTypeTest extends TestCase
     {
         $type = new VoidType;
 
-        $this->assertFalse($type->allowsNull());
+        $this->assertFalse($type->allowsNull);
     }
 
     public function testCanBeQueriedForType(): void

--- a/tests/unit/type/VoidTypeTest.php
+++ b/tests/unit/type/VoidTypeTest.php
@@ -21,7 +21,7 @@ final class VoidTypeTest extends TestCase
 {
     public function testHasName(): void
     {
-        $this->assertSame('void', (new VoidType)->name());
+        $this->assertSame('void', (new VoidType)->name);
     }
 
     #[DataProvider('assignableTypes')]


### PR DESCRIPTION
Noticed some more improvements to be made, thought I'd waste some time doing just that.

Needless to say, this is a BC-break because of all the method-to-public-property changes.

I see that CI/Coding Guidelines fails because of `braces` php-cs-fixer rule; that is because php-cs-fixer does not yet support constructor property promotion, it wants the empty braces to be split into two lines.