### PR TITLE
Fix ObjectType::isAssignable() to correctly handle class aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
             "tests/_fixture"
         ],
         "files": [
-            "tests/_fixture/callback_function.php"
+            "tests/_fixture/callback_function.php",
+            "tests/_fixture/class_alias.php"
         ]
     },
     "extra": {

--- a/src/ObjectType.php
+++ b/src/ObjectType.php
@@ -34,7 +34,7 @@ final class ObjectType extends Type
         }
 
         if ($other instanceof self) {
-            if (0 === \strcasecmp($this->className->getQualifiedName(), $other->className->getQualifiedName())) {
+            if (0 === \strcasecmp($this->className->getCanonicalName(), $other->className->getCanonicalName())) {
                 return true;
             }
 

--- a/src/TypeName.php
+++ b/src/TypeName.php
@@ -21,6 +21,11 @@ final class TypeName
      */
     private $simpleName;
 
+    /**
+     * @var string
+     */
+    private $canonicalName;
+
     public static function fromQualifiedName(string $fullClassName): self
     {
         if ($fullClassName[0] === '\\') {
@@ -51,6 +56,15 @@ final class TypeName
 
         $this->namespaceName = $namespaceName;
         $this->simpleName    = $simpleName;
+
+        try {
+            $this->canonicalName = (new \ReflectionClass($this->getQualifiedName()))->name;
+        } catch (\ReflectionException) {
+            // If the class represented by instance does not exist, it can't be an
+            // alias of existing class. We can safely assume the qualified name is
+            // also cannonical name.
+            $this->canonicalName = $this->getQualifiedName();
+        }
     }
 
     public function getNamespaceName(): ?string
@@ -73,5 +87,15 @@ final class TypeName
     public function isNamespaced(): bool
     {
         return $this->namespaceName !== null;
+    }
+
+    public function isCanonical(): bool
+    {
+        return $this->getQualifiedName() === $this->getCanonicalName();
+    }
+
+    public function getCanonicalName(): string
+    {
+        return $this->canonicalName;
     }
 }

--- a/tests/_fixture/class_alias.php
+++ b/tests/_fixture/class_alias.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/type.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Type\TestFixture;
+
+\class_alias(ParentClass::class, '\SebastianBergmann\Type\TestFixture\ParentClassAlias');

--- a/tests/unit/ObjectTypeTest.php
+++ b/tests/unit/ObjectTypeTest.php
@@ -12,6 +12,7 @@ namespace SebastianBergmann\Type;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Type\TestFixture\ChildClass;
 use SebastianBergmann\Type\TestFixture\ParentClass;
+use SebastianBergmann\Type\TestFixture\ParentClassAlias;
 
 /**
  * @covers \SebastianBergmann\Type\ObjectType
@@ -106,6 +107,26 @@ final class ObjectTypeTest extends TestCase
         );
 
         $this->assertFalse($someClass->isAssignable(Type::fromValue(null, true)));
+    }
+
+    public function testClassAliasIsAssignableToClassItIsAliasing(): void
+    {
+        $someClass = new ObjectType(
+            TypeName::fromQualifiedName(ParentClassAlias::class),
+            false
+        );
+
+        $this->assertTrue($someClass->isAssignable($this->parentClass));
+    }
+
+    public function testClassIsAssignableToItsAliasClass(): void
+    {
+        $someClass = new ObjectType(
+            TypeName::fromQualifiedName(ParentClassAlias::class),
+            false
+        );
+
+        $this->assertTrue($this->parentClass->isAssignable($someClass));
     }
 
     public function testPreservesNullNotAllowed(): void

--- a/tests/unit/TypeNameTest.php
+++ b/tests/unit/TypeNameTest.php
@@ -11,6 +11,9 @@ namespace SebastianBergmann\Type;
 
 use PHPUnit\Framework\TestCase;
 
+use SebastianBergmann\Type\TestFixture\ParentClass;
+use SebastianBergmann\Type\TestFixture\ParentClassAlias;
+
 /**
  * @covers \SebastianBergmann\Type\TypeName
  */
@@ -55,5 +58,31 @@ final class TypeNameTest extends TestCase
         $this->assertNull($typeName->getNamespaceName());
         $this->assertEquals('Bar', $typeName->getQualifiedName());
         $this->assertEquals('Bar', $typeName->getSimpleName());
+    }
+
+    public function testCannonicalWithClassNotExist(): void
+    {
+        $typeName = TypeName::fromQualifiedName('Bar');
+
+        $this->assertEquals(true, $typeName->isCanonical());
+        $this->assertEquals('Bar', $typeName->getCanonicalName());
+    }
+
+    public function testCannonicalWithClassExist(): void
+    {
+        $typeName = TypeName::fromQualifiedName(ParentClass::class);
+
+        $this->assertEquals(true, $typeName->isCanonical());
+        $this->assertEquals(ParentClass::class, $typeName->getQualifiedName());
+        $this->assertEquals(ParentClass::class, $typeName->getCanonicalName());
+    }
+
+    public function testCannonicalWithClassAlias(): void
+    {
+        $typeName = TypeName::fromQualifiedName(ParentClassAlias::class);
+
+        $this->assertEquals(false, $typeName->isCanonical());
+        $this->assertEquals(ParentClassAlias::class, $typeName->getQualifiedName());
+        $this->assertEquals(ParentClass::class, $typeName->getCanonicalName());
     }
 }


### PR DESCRIPTION
Issue: #18 

This pull request is loosely based on PR #17 by  @vojtabiberle. I have rebased it to branch 1.1 and fixed hopefully all code review comments from that time.

I have added few modifications on top of it:

- canonical (un-aliased) name is precomputed and stored in TypeName instance
- canonical name of non-existent class is assumed to be its qualified name (to prevent exception when querying it)
