### PR TITLE
Fix ObjectType::isAssignable() to correctly handle class aliases (for 3.2 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         ],
         "files": [
             "tests/_fixture/callback_function.php",
-            "tests/_fixture/functions_that_declare_return_types.php"
+            "tests/_fixture/functions_that_declare_return_types.php",
+            "tests/_fixture/class_alias.php"
         ]
     },
     "extra": {

--- a/src/TypeName.php
+++ b/src/TypeName.php
@@ -27,6 +27,11 @@ final class TypeName
      */
     private $simpleName;
 
+    /**
+     * @var string
+     */
+    private $canonicalName;
+
     public static function fromQualifiedName(string $fullClassName): self
     {
         if ($fullClassName[0] === '\\') {
@@ -57,6 +62,15 @@ final class TypeName
 
         $this->namespaceName = $namespaceName;
         $this->simpleName    = $simpleName;
+
+        try {
+            $this->canonicalName = (new \ReflectionClass($this->qualifiedName()))->name;
+        } catch (\ReflectionException) {
+            // If the class represented by instance does not exist, it can't be an
+            // alias of existing class. We can safely assume the qualified name is
+            // also cannonical name.
+            $this->canonicalName = $this->qualifiedName();
+        }
     }
 
     public function namespaceName(): ?string
@@ -79,5 +93,15 @@ final class TypeName
     public function isNamespaced(): bool
     {
         return $this->namespaceName !== null;
+    }
+
+    public function isCanonical(): bool
+    {
+        return $this->qualifiedName() === $this->canonicalName();
+    }
+
+    public function canonicalName(): string
+    {
+        return $this->canonicalName;
     }
 }

--- a/src/type/ObjectType.php
+++ b/src/type/ObjectType.php
@@ -37,7 +37,7 @@ final class ObjectType extends Type
         }
 
         if ($other instanceof self) {
-            if (0 === strcasecmp($this->className->qualifiedName(), $other->className->qualifiedName())) {
+            if (0 === strcasecmp($this->className->canonicalName(), $other->className->canonicalName())) {
                 return true;
             }
 

--- a/tests/_fixture/class_alias.php
+++ b/tests/_fixture/class_alias.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/type.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Type\TestFixture;
+
+\class_alias(ParentClass::class, '\SebastianBergmann\Type\TestFixture\ParentClassAlias');

--- a/tests/unit/TypeNameTest.php
+++ b/tests/unit/TypeNameTest.php
@@ -12,6 +12,9 @@ namespace SebastianBergmann\Type;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+use SebastianBergmann\Type\TestFixture\ParentClass;
+use SebastianBergmann\Type\TestFixture\ParentClassAlias;
+
 /**
  * @covers \SebastianBergmann\Type\TypeName
  */
@@ -56,5 +59,31 @@ final class TypeNameTest extends TestCase
         $this->assertNull($typeName->namespaceName());
         $this->assertSame('Bar', $typeName->qualifiedName());
         $this->assertSame('Bar', $typeName->simpleName());
+    }
+
+    public function testCannonicalWithClassNotExist(): void
+    {
+        $typeName = TypeName::fromQualifiedName('Bar');
+
+        $this->assertEquals(true, $typeName->isCanonical());
+        $this->assertEquals('Bar', $typeName->canonicalName());
+    }
+
+    public function testCannonicalWithClassExist(): void
+    {
+        $typeName = TypeName::fromQualifiedName(ParentClass::class);
+
+        $this->assertEquals(true, $typeName->isCanonical());
+        $this->assertEquals(ParentClass::class, $typeName->qualifiedName());
+        $this->assertEquals(ParentClass::class, $typeName->canonicalName());
+    }
+
+    public function testCannonicalWithClassAlias(): void
+    {
+        $typeName = TypeName::fromQualifiedName(ParentClassAlias::class);
+
+        $this->assertEquals(false, $typeName->isCanonical());
+        $this->assertEquals(ParentClassAlias::class, $typeName->qualifiedName());
+        $this->assertEquals(ParentClass::class, $typeName->canonicalName());
     }
 }

--- a/tests/unit/type/ObjectTypeTest.php
+++ b/tests/unit/type/ObjectTypeTest.php
@@ -13,6 +13,7 @@ use function strtolower;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Type\TestFixture\ChildClass;
 use SebastianBergmann\Type\TestFixture\ParentClass;
+use SebastianBergmann\Type\TestFixture\ParentClassAlias;
 
 /**
  * @covers \SebastianBergmann\Type\ObjectType
@@ -112,6 +113,26 @@ final class ObjectTypeTest extends TestCase
         );
 
         $this->assertFalse($someClass->isAssignable(Type::fromValue(null, true)));
+    }
+
+    public function testClassAliasIsAssignableToClassItIsAliasing(): void
+    {
+        $someClass = new ObjectType(
+            TypeName::fromQualifiedName(ParentClassAlias::class),
+            false
+        );
+
+        $this->assertTrue($someClass->isAssignable($this->parentClass));
+    }
+
+    public function testClassIsAssignableToItsAliasClass(): void
+    {
+        $someClass = new ObjectType(
+            TypeName::fromQualifiedName(ParentClassAlias::class),
+            false
+        );
+
+        $this->assertTrue($this->parentClass->isAssignable($someClass));
     }
 
     public function testPreservesNullNotAllowed(): void


### PR DESCRIPTION
Issue: https://github.com/sebastianbergmann/type/issues/18

This is a code from pull request #30 applied on branch 3.2 as requested.